### PR TITLE
Use RunShellCommand | Add error statements to stderr

### DIFF
--- a/main/ahb_for_sles.go
+++ b/main/ahb_for_sles.go
@@ -328,18 +328,21 @@ var installCallbackFunc vmextension.CallbackFunc = func(ext *vmextension.VMExten
 			// need to install the right version
 			handlePackageError := _handlePackageInstall(ahbInfo)
 			if handlePackageError != nil {
+				fmt.Println("Extension enable failed. Reason=" + handlePackageError.Error())
 				return handlePackageError
 			}
 		} else {
 			if addonError == nil {
 				// both packages are in the system and
 				// the version is correct
+				fmt.Println("Extension install succeeded")
 				return nil
 			} else {
 				// missing addon package
 				// add addon
 				handlePackageError := _handlePackageInstall(ahbInfo)
 				if handlePackageError != nil {
+					fmt.Println("Extension enable failed. Reason=" + handlePackageError.Error())
 					return handlePackageError
 				}
 			}
@@ -347,9 +350,12 @@ var installCallbackFunc vmextension.CallbackFunc = func(ext *vmextension.VMExten
 	} else {
 		handlePackageError := _handlePackageInstall(ahbInfo)
 		if handlePackageError != nil {
+			fmt.Println("Extension enable failed. Reason=" + handlePackageError.Error())
 			return handlePackageError
 		}
 	}
+
+	fmt.Println("Extension install succeeded")
 	return nil
 }
 
@@ -359,6 +365,7 @@ var enableCallbackFunc vmextension.EnableCallbackFunc = func(ext *vmextension.VM
 	status := "success"
 	_, err := os.Stat(ahbInfo.AddonPath)
 	if err != nil {
+		fmt.Println("Extension enable failed. Reason=" + err.Error())
 		return "failure", err
 	}
 	//2. enable and start the timer


### PR DESCRIPTION
Why is it required? 
Currently, the error when running shell commands through golang is not getting logged/printed anywhere, making the debugging process difficult. Example: 

<img width="1406" alt="image" src="https://user-images.githubusercontent.com/28175383/177652123-e012b047-57ae-4a1f-9cc3-7f292b238800.png">


What are we doing now? 
- Using RunShellCommand function that would a) Use a default timeout b) Print the error when running the command to stderr
- Using fmt.Fprintln to push the error in stderr and ensuring all error paths are getting the error message printed