### PR TITLE
Update version of azure-extension-platform | Add Telemetry Events to Extension 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/SUSE-Enceladus/ahb-extension
 go 1.17
 
 require (
-	github.com/Azure/azure-extension-platform v0.0.0-20220727161245-67e58652b30d
+	github.com/Azure/azure-extension-platform v0.0.0-20220805171336-0dc957a76b67
 	github.com/go-kit/kit v0.12.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/SUSE-Enceladus/ahb-extension
 go 1.17
 
 require (
-	github.com/Azure/azure-extension-platform v0.0.0-20220301222126-2656bbc0a09f
+	github.com/Azure/azure-extension-platform v0.0.0-20220727161245-67e58652b30d
 	github.com/go-kit/kit v0.12.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Azure/azure-extension-platform v0.0.0-20220301222126-2656bbc0a09f h1:
 github.com/Azure/azure-extension-platform v0.0.0-20220301222126-2656bbc0a09f/go.mod h1:1hEkO8M1zN/SQpdFOTDDMTNfeE1Q2tCHmEXXiHrWTgo=
 github.com/Azure/azure-extension-platform v0.0.0-20220727161245-67e58652b30d h1:afAVUzTccJtQfP+cWsTYlAADrNZAMRQgKzOJ9ba/6kE=
 github.com/Azure/azure-extension-platform v0.0.0-20220727161245-67e58652b30d/go.mod h1:1hEkO8M1zN/SQpdFOTDDMTNfeE1Q2tCHmEXXiHrWTgo=
+github.com/Azure/azure-extension-platform v0.0.0-20220805171336-0dc957a76b67 h1:Of1ijxH2Mxlq1l5vZOhBmqxDhlf7iAiaGkyMjoN634A=
+github.com/Azure/azure-extension-platform v0.0.0-20220805171336-0dc957a76b67/go.mod h1:1hEkO8M1zN/SQpdFOTDDMTNfeE1Q2tCHmEXXiHrWTgo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.12.0 h1:e4o3o3IsBfAKQh5Qbbiqyfu97Ku7jrO/JbohvztANh4=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/azure-extension-platform v0.0.0-20220301222126-2656bbc0a09f h1:uAH5ceF4hlDhrDXgiwJhksBRn5WNPkhGAoMFpT57uf4=
 github.com/Azure/azure-extension-platform v0.0.0-20220301222126-2656bbc0a09f/go.mod h1:1hEkO8M1zN/SQpdFOTDDMTNfeE1Q2tCHmEXXiHrWTgo=
+github.com/Azure/azure-extension-platform v0.0.0-20220727161245-67e58652b30d h1:afAVUzTccJtQfP+cWsTYlAADrNZAMRQgKzOJ9ba/6kE=
+github.com/Azure/azure-extension-platform v0.0.0-20220727161245-67e58652b30d/go.mod h1:1hEkO8M1zN/SQpdFOTDDMTNfeE1Q2tCHmEXXiHrWTgo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.12.0 h1:e4o3o3IsBfAKQh5Qbbiqyfu97Ku7jrO/JbohvztANh4=

--- a/main/ahb_for_sles.go
+++ b/main/ahb_for_sles.go
@@ -54,7 +54,7 @@ const (
 	UPDATE_EVENT             = "Update"
 	OPERATION_START_MSG      = "AHBForSLES extension %s started..."
 	OPERATION_FAILURE_MSG    = "AHBForSLES extension %s finished. Result=Failure; Reason=%v"
-	OPERATION_COMPLETION_MSG = "AHBForSLES extension %s completed"
+	OPERATION_COMPLETION_MSG = "AHBForSLES extension %s completed. Result=Success"
 )
 
 type AHBInfo struct {

--- a/main/ahb_for_sles.go
+++ b/main/ahb_for_sles.go
@@ -50,7 +50,7 @@ const (
 	INSTALL_EVENT            = "Install"
 	ENABLE_EVENT             = "Enable"
 	DISABLE_EVENT            = "Disable"
-	UNINSTALL_EVENT          = "UNINSTALL"
+	UNINSTALL_EVENT          = "Uninstall"
 	UPDATE_EVENT             = "Update"
 	OPERATION_START_MSG      = "AHBForSLES extension %s started..."
 	OPERATION_FAILURE_MSG    = "AHBForSLES extension %s finished. Result=Failure; Reason=%v"

--- a/main/ahb_for_sles.go
+++ b/main/ahb_for_sles.go
@@ -52,6 +52,7 @@ const (
 	DISABLE_EVENT            = "Disable"
 	UNINSTALL_EVENT          = "Uninstall"
 	UPDATE_EVENT             = "Update"
+	INITIALIZATION_EVENT     = "Initialization"
 	OPERATION_START_MSG      = "AHBForSLES extension %s started..."
 	OPERATION_FAILURE_MSG    = "AHBForSLES extension %s finished. Result=Failure; Reason=%v"
 	OPERATION_COMPLETION_MSG = "AHBForSLES extension %s completed. Result=Success"
@@ -470,8 +471,8 @@ func getExtensionAndRun() error {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Extension initialization failed. Reason="+err.Error())
 		vmExt.ExtensionEvents.LogErrorEvent(
-			"Initialization",
-			fmt.Sprintf("AHBForSLES extension initialization finished. Result=Failure; Reason=%v", err.Error()))
+			INITIALIZATION_EVENT,
+			fmt.Sprintf(OPERATION_FAILURE_MSG, INITIALIZATION_EVENT, err.Error()))
 		return err
 	}
 	vmExt.Do()


### PR DESCRIPTION
Why is this PR required?
- Fetch latest version of azure-extension-platform that contains critical bug fix for extension install.
Install command returning success even in case of failure
Bug: https://github.com/Azure/azure-extension-platform/commit/67e58652b30d119aa84715cb48e290b6fd714543
Bug: Use correct version of extension during logging: https://github.com/Azure/azure-extension-platform/commit/0dc957a76b678ea385889b0f1b123d5be58994b8
- Add extension events for better telemetry

Changes made:
- Using ext.ExtensionEvents.LogInformationalEvent/LogErrorEvents, we are sending the telemetry events
- Updated go.mod/go.sum with latest version of azure-extension-platform by recreating these files